### PR TITLE
Add sample home page view

### DIFF
--- a/Yuki/ContentView.swift
+++ b/Yuki/ContentView.swift
@@ -9,13 +9,7 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
-        .padding()
+        HomeView()
     }
 }
 

--- a/Yuki/HomeView.swift
+++ b/Yuki/HomeView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 24) {
+                Spacer()
+                VStack(spacing: 8) {
+                    Image(systemName: "house.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 80, height: 80)
+                        .foregroundColor(.white)
+
+                    Text("Welcome to Yuki")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .foregroundStyle(.white)
+                }
+                
+                Text("Your next favorite app experience starts here.")
+                    .multilineTextAlignment(.center)
+                    .font(.headline)
+                    .foregroundStyle(.white.opacity(0.9))
+                    .padding(.horizontal)
+
+                Spacer()
+                Button(action: {}) {
+                    Text("Get Started")
+                        .font(.headline)
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(Color.white)
+                        .foregroundColor(.blue)
+                        .cornerRadius(12)
+                        .padding(.horizontal)
+                }
+                .padding(.bottom, 40)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(
+                LinearGradient(
+                    gradient: Gradient(colors: [.blue, .purple]),
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                .ignoresSafeArea()
+            )
+            .navigationBarHidden(true)
+        }
+    }
+}
+
+#Preview {
+    HomeView()
+}


### PR DESCRIPTION
## Summary
- add a `HomeView` showcasing a simple home page layout
- use `HomeView` in `ContentView`

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6881d324fc9483289b47cae63f3b32c4