### PR TITLE
Add login and register views

### DIFF
--- a/Yuki/Brand.swift
+++ b/Yuki/Brand.swift
@@ -1,0 +1,5 @@
+import SwiftUI
+
+extension Color {
+    static let brand = Color(red: 214/255, green: 86/255, blue: 66/255)
+}

--- a/Yuki/HomeView.swift
+++ b/Yuki/HomeView.swift
@@ -25,16 +25,27 @@ struct HomeView: View {
                     .padding(.horizontal)
 
                 Spacer()
-                Button(action: {}) {
-                    Text("Get Started")
-                        .font(.headline)
-                        .padding()
-                        .frame(maxWidth: .infinity)
-                        .background(Color.white)
-                        .foregroundColor(.blue)
-                        .cornerRadius(12)
-                        .padding(.horizontal)
+                VStack(spacing: 12) {
+                    NavigationLink(destination: LoginView()) {
+                        Text("Login")
+                            .font(.headline)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                            .background(Color.brand)
+                            .foregroundColor(.white)
+                            .cornerRadius(12)
+                    }
+                    NavigationLink(destination: RegisterView()) {
+                        Text("Register")
+                            .font(.headline)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                            .background(Color.white)
+                            .foregroundColor(Color.brand)
+                            .cornerRadius(12)
+                    }
                 }
+                .padding(.horizontal)
                 .padding(.bottom, 40)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Yuki/LoginView.swift
+++ b/Yuki/LoginView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct LoginView: View {
+    @State private var email: String = ""
+    @State private var password: String = ""
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Login")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+                .padding(.top, 40)
+            TextField("Email", text: $email)
+                .textFieldStyle(.roundedBorder)
+                .autocapitalization(.none)
+                .padding(.horizontal)
+            SecureField("Password", text: $password)
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal)
+            Button(action: {}) {
+                Text("Login")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.brand)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                    .padding(.horizontal)
+            }
+            Spacer()
+        }
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationView {
+        LoginView()
+    }
+}

--- a/Yuki/RegisterView.swift
+++ b/Yuki/RegisterView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct RegisterView: View {
+    @State private var name: String = ""
+    @State private var email: String = ""
+    @State private var password: String = ""
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Register")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+                .padding(.top, 40)
+            TextField("Name", text: $name)
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal)
+            TextField("Email", text: $email)
+                .textFieldStyle(.roundedBorder)
+                .autocapitalization(.none)
+                .padding(.horizontal)
+            SecureField("Password", text: $password)
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal)
+            Button(action: {}) {
+                Text("Register")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.brand)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                    .padding(.horizontal)
+            }
+            Spacer()
+        }
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationView {
+        RegisterView()
+    }
+}


### PR DESCRIPTION
## Summary
- create a `Color.brand` constant for the primary color `#D65642`
- add `LoginView` and `RegisterView`
- update `HomeView` to navigate to the new screens

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6881d92d83108328877cbe4936ab33cc