### PR TITLE
Add artist selection and scheduling flow

### DIFF
--- a/Yuki/ArtistSelectionView.swift
+++ b/Yuki/ArtistSelectionView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct Artist: Identifiable {
+    let id: Int
+    let name: String
+}
+
+struct ArtistSelectionView: View {
+    private let artists = [
+        Artist(id: 1, name: "Zulaa"),
+        Artist(id: 2, name: "Ari"),
+        Artist(id: 3, name: "Azaa"),
+        Artist(id: 4, name: "Saran")
+    ]
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Select Artist")
+                .font(.title)
+                .fontWeight(.bold)
+                .padding(.top, 32)
+
+            ForEach(artists) { artist in
+                NavigationLink(destination: ScheduleView(artist: artist.name)) {
+                    Text(artist.name)
+                        .foregroundColor(.primary)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.gray.opacity(0.2))
+                        .cornerRadius(10)
+                }
+                .padding(.horizontal)
+            }
+
+            Spacer()
+        }
+        .navigationTitle("Artists")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationView {
+        ArtistSelectionView()
+    }
+}

--- a/Yuki/HomeView.swift
+++ b/Yuki/HomeView.swift
@@ -46,6 +46,15 @@ struct HomeView: View {
                             .foregroundColor(Color.brand)
                             .cornerRadius(12)
                     }
+                    NavigationLink(destination: ArtistSelectionView()) {
+                        Text("Book Appointment")
+                            .font(.headline)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                            .background(Color.white)
+                            .foregroundColor(Color.brand)
+                            .cornerRadius(12)
+                    }
                 }
                 .padding(.horizontal)
                 .padding(.bottom, 40)

--- a/Yuki/ScheduleView.swift
+++ b/Yuki/ScheduleView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct ScheduleView: View {
+    let artist: String
+    @State private var appointmentDate = Date()
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Schedule with \(artist)")
+                .font(.title)
+                .fontWeight(.bold)
+                .padding(.top, 32)
+
+            DatePicker("Select time", selection: $appointmentDate, displayedComponents: [.date, .hourAndMinute])
+                .datePickerStyle(.graphical)
+                .padding()
+
+            Spacer()
+        }
+        .navigationTitle("Scheduling")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationView {
+        ScheduleView(artist: "Zulaa")
+    }
+}


### PR DESCRIPTION
## Summary
- enable booking from home screen
- add artist selection list with names Zulaa, Ari, Azaa and Saran
- create scheduling view with date picker

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6881dd0f54e083288c87014119f5e6c6