### PR TITLE
Limit scheduling to upcoming 3 days

### DIFF
--- a/Yuki/ScheduleView.swift
+++ b/Yuki/ScheduleView.swift
@@ -2,20 +2,80 @@ import SwiftUI
 
 struct ScheduleView: View {
     let artist: String
-    @State private var appointmentDate = Date()
+
+    // Next three days starting from today
+    private var days: [Date] {
+        let calendar = Calendar.current
+        let start = calendar.startOfDay(for: Date())
+        return (0..<3).compactMap { calendar.date(byAdding: .day, value: $0, to: start) }
+    }
+
+    @State private var selectedDay: Date = Calendar.current.startOfDay(for: Date())
+    @State private var selectedTime: Date?
+
+    private var columns: [GridItem] { Array(repeating: .init(.flexible()), count: 3) }
+
+    private var dayFormatter: DateFormatter {
+        let df = DateFormatter()
+        df.dateFormat = "MMM d"
+        return df
+    }
+
+    private var timeFormatter: DateFormatter {
+        let df = DateFormatter()
+        df.dateFormat = "h:mm a"
+        return df
+    }
+
+    private func timeSlots(for day: Date) -> [Date] {
+        let calendar = Calendar.current
+        guard let start = calendar.date(bySettingHour: 9, minute: 0, second: 0, of: day) else { return [] }
+        return (0...24).compactMap { calendar.date(byAdding: .minute, value: $0 * 30, to: start) }
+    }
 
     var body: some View {
-        VStack(spacing: 20) {
-            Text("Schedule with \(artist)")
-                .font(.title)
-                .fontWeight(.bold)
-                .padding(.top, 32)
+        ScrollView {
+            VStack(spacing: 20) {
+                Text("Schedule with \(artist)")
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .padding(.top, 32)
 
-            DatePicker("Select time", selection: $appointmentDate, displayedComponents: [.date, .hourAndMinute])
-                .datePickerStyle(.graphical)
-                .padding()
+                // Day selection
+                HStack(spacing: 12) {
+                    ForEach(days, id: \.self) { day in
+                        Button(action: {
+                            selectedDay = day
+                            selectedTime = nil
+                        }) {
+                            Text(dayFormatter.string(from: day))
+                                .foregroundColor(selectedDay == day ? .white : .primary)
+                                .padding(8)
+                                .frame(maxWidth: .infinity)
+                                .background(selectedDay == day ? Color.brand : Color.gray.opacity(0.2))
+                                .cornerRadius(8)
+                        }
+                    }
+                }
+                .padding(.horizontal)
 
-            Spacer()
+                // Time slot selection
+                LazyVGrid(columns: columns, spacing: 12) {
+                    ForEach(timeSlots(for: selectedDay), id: \.self) { slot in
+                        Button(action: { selectedTime = slot }) {
+                            Text(timeFormatter.string(from: slot))
+                                .frame(maxWidth: .infinity)
+                                .padding(8)
+                                .foregroundColor(selectedTime == slot ? .white : .primary)
+                                .background(selectedTime == slot ? Color.brand : Color.gray.opacity(0.2))
+                                .cornerRadius(8)
+                        }
+                    }
+                }
+                .padding(.horizontal)
+
+                Spacer()
+            }
         }
         .navigationTitle("Scheduling")
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
## Summary
- restrict scheduling options to the next three days only
- show available times between 9 AM and 9 PM as selectable slots

## Testing
- `swift --version`
- `swift test -v` *(fails: `Could not find Package.swift`)*

------
https://chatgpt.com/codex/tasks/task_e_6881deb21ee0832896cee80bca6c0492