### PR TITLE
Add Firebase login and registration

### DIFF
--- a/Yuki/AuthViewModel.swift
+++ b/Yuki/AuthViewModel.swift
@@ -1,0 +1,43 @@
+import Foundation
+import FirebaseAuth
+
+class AuthViewModel: ObservableObject {
+    @Published var user: User?
+    
+    init() {
+        self.user = Auth.auth().currentUser
+        Auth.auth().addStateDidChangeListener { _, user in
+            self.user = user
+        }
+    }
+    
+    func register(name: String, email: String, password: String, completion: @escaping (Error?) -> Void) {
+        Auth.auth().createUser(withEmail: email, password: password) { result, error in
+            if let user = result?.user {
+                let changeRequest = user.createProfileChangeRequest()
+                changeRequest.displayName = name
+                changeRequest.commitChanges { _ in }
+                self.user = user
+            }
+            completion(error)
+        }
+    }
+    
+    func login(email: String, password: String, completion: @escaping (Error?) -> Void) {
+        Auth.auth().signIn(withEmail: email, password: password) { result, error in
+            if let user = result?.user {
+                self.user = user
+            }
+            completion(error)
+        }
+    }
+    
+    func signOut() {
+        do {
+            try Auth.auth().signOut()
+            self.user = nil
+        } catch {
+            print("Error signing out: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Yuki/LoginView.swift
+++ b/Yuki/LoginView.swift
@@ -3,6 +3,9 @@ import SwiftUI
 struct LoginView: View {
     @State private var email: String = ""
     @State private var password: String = ""
+    @State private var alertMessage: String = ""
+    @State private var showAlert = false
+    @EnvironmentObject var auth: AuthViewModel
     
     var body: some View {
         VStack(spacing: 20) {
@@ -17,7 +20,16 @@ struct LoginView: View {
             SecureField("Password", text: $password)
                 .textFieldStyle(.roundedBorder)
                 .padding(.horizontal)
-            Button(action: {}) {
+            Button(action: {
+                auth.login(email: email, password: password) { error in
+                    if let error = error {
+                        alertMessage = error.localizedDescription
+                    } else {
+                        alertMessage = "Logged in successfully"
+                    }
+                    showAlert = true
+                }
+            }) {
                 Text("Login")
                     .frame(maxWidth: .infinity)
                     .padding()
@@ -29,11 +41,15 @@ struct LoginView: View {
             Spacer()
         }
         .navigationBarTitleDisplayMode(.inline)
+        .alert(isPresented: $showAlert) {
+            Alert(title: Text(alertMessage))
+        }
     }
 }
 
 #Preview {
     NavigationView {
         LoginView()
+            .environmentObject(AuthViewModel())
     }
 }

--- a/Yuki/RegisterView.swift
+++ b/Yuki/RegisterView.swift
@@ -4,6 +4,9 @@ struct RegisterView: View {
     @State private var name: String = ""
     @State private var email: String = ""
     @State private var password: String = ""
+    @State private var alertMessage: String = ""
+    @State private var showAlert = false
+    @EnvironmentObject var auth: AuthViewModel
     
     var body: some View {
         VStack(spacing: 20) {
@@ -21,7 +24,16 @@ struct RegisterView: View {
             SecureField("Password", text: $password)
                 .textFieldStyle(.roundedBorder)
                 .padding(.horizontal)
-            Button(action: {}) {
+            Button(action: {
+                auth.register(name: name, email: email, password: password) { error in
+                    if let error = error {
+                        alertMessage = error.localizedDescription
+                    } else {
+                        alertMessage = "Registered successfully"
+                    }
+                    showAlert = true
+                }
+            }) {
                 Text("Register")
                     .frame(maxWidth: .infinity)
                     .padding()
@@ -33,11 +45,15 @@ struct RegisterView: View {
             Spacer()
         }
         .navigationBarTitleDisplayMode(.inline)
+        .alert(isPresented: $showAlert) {
+            Alert(title: Text(alertMessage))
+        }
     }
 }
 
 #Preview {
     NavigationView {
         RegisterView()
+            .environmentObject(AuthViewModel())
     }
 }

--- a/Yuki/YukiApp.swift
+++ b/Yuki/YukiApp.swift
@@ -13,12 +13,14 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 struct YourApp: App {
   // register app delegate for Firebase setup
   @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+  @StateObject private var authViewModel = AuthViewModel()
 
   var body: some Scene {
     WindowGroup {
       NavigationView {
         ContentView()
       }
+      .environmentObject(authViewModel)
     }
   }
 }


### PR DESCRIPTION
## Summary
- create `AuthViewModel` to wrap FirebaseAuth calls
- add environment object to `YukiApp`
- implement login and registration actions using Firebase

## Testing
- `swiftc -parse Yuki/AuthViewModel.swift Yuki/LoginView.swift Yuki/RegisterView.swift Yuki/Brand.swift Yuki/YukiApp.swift Yuki/ContentView.swift Yuki/HomeView.swift Yuki/ArtistSelectionView.swift Yuki/LocationSelectionView.swift Yuki/ScheduleView.swift`
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68831b7b58248328ae604e3cca55486b