### PR TITLE
Add Google login and profile storage

### DIFF
--- a/Yuki/AuthViewModel.swift
+++ b/Yuki/AuthViewModel.swift
@@ -1,5 +1,8 @@
 import Foundation
 import FirebaseAuth
+import FirebaseFirestore
+import FirebaseCore
+import GoogleSignIn
 
 class AuthViewModel: ObservableObject {
     @Published var user: User?
@@ -28,6 +31,54 @@ class AuthViewModel: ObservableObject {
             if let user = result?.user {
                 self.user = user
             }
+            completion(error)
+        }
+    }
+
+    func loginWithGoogle(presenting: UIViewController, completion: @escaping (Error?) -> Void) {
+        guard let clientID = FirebaseApp.app()?.options.clientID else {
+            completion(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Missing client ID"]))
+            return
+        }
+
+        GIDSignIn.sharedInstance.configuration = GIDConfiguration(clientID: clientID)
+        GIDSignIn.sharedInstance.signIn(withPresenting: presenting) { result, error in
+            if let error = error {
+                completion(error)
+                return
+            }
+
+            guard
+                let idToken = result?.user.idToken?.tokenString,
+                let accessToken = result?.user.accessToken.tokenString
+            else {
+                completion(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to get auth token"]))
+                return
+            }
+
+            let credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: accessToken)
+            Auth.auth().signIn(with: credential) { authResult, error in
+                if let user = authResult?.user {
+                    self.user = user
+                }
+                completion(error)
+            }
+        }
+    }
+
+    func saveProfile(name: String, phone: String, completion: @escaping (Error?) -> Void) {
+        guard let uid = Auth.auth().currentUser?.uid else {
+            completion(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "No user found"]))
+            return
+        }
+
+        let data: [String: Any] = [
+            "name": name,
+            "phone": phone,
+            "email": Auth.auth().currentUser?.email ?? ""
+        ]
+
+        Firestore.firestore().collection("users").document(uid).setData(data) { error in
             completion(error)
         }
     }

--- a/Yuki/HomeView.swift
+++ b/Yuki/HomeView.swift
@@ -55,6 +55,15 @@ struct HomeView: View {
                             .foregroundColor(Color.brand)
                             .cornerRadius(12)
                     }
+                    NavigationLink(destination: ProfileView()) {
+                        Text("Profile")
+                            .font(.headline)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                            .background(Color.white)
+                            .foregroundColor(Color.brand)
+                            .cornerRadius(12)
+                    }
                 }
                 .padding(.horizontal)
                 .padding(.bottom, 40)

--- a/Yuki/LoginView.swift
+++ b/Yuki/LoginView.swift
@@ -38,6 +38,27 @@ struct LoginView: View {
                     .cornerRadius(10)
                     .padding(.horizontal)
             }
+            Button(action: {
+                if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                   let root = scene.windows.first?.rootViewController {
+                    auth.loginWithGoogle(presenting: root) { error in
+                        if let error = error {
+                            alertMessage = error.localizedDescription
+                        } else {
+                            alertMessage = "Logged in with Google"
+                        }
+                        showAlert = true
+                    }
+                }
+            }) {
+                Text("Sign in with Google")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.brand)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                    .padding(.horizontal)
+            }
             Spacer()
         }
         .navigationBarTitleDisplayMode(.inline)

--- a/Yuki/ProfileView.swift
+++ b/Yuki/ProfileView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import FirebaseAuth
+
+struct ProfileView: View {
+    @EnvironmentObject var auth: AuthViewModel
+    @State private var name: String = ""
+    @State private var phone: String = ""
+    @State private var alertMessage: String = ""
+    @State private var showAlert = false
+
+    var body: some View {
+        VStack(spacing: 20) {
+            if auth.user != nil {
+                TextField("Name", text: $name)
+                    .textFieldStyle(.roundedBorder)
+                    .padding(.horizontal)
+
+                TextField("Phone", text: $phone)
+                    .textFieldStyle(.roundedBorder)
+                    .padding(.horizontal)
+
+                Button(action: {
+                    auth.saveProfile(name: name, phone: phone) { error in
+                        if let error = error {
+                            alertMessage = error.localizedDescription
+                        } else {
+                            alertMessage = "Profile saved"
+                        }
+                        showAlert = true
+                    }
+                }) {
+                    Text("Save")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.brand)
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                        .padding(.horizontal)
+                }
+            } else {
+                Text("Please log in first.")
+            }
+            Spacer()
+        }
+        .navigationTitle("Profile")
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(isPresented: $showAlert) {
+            Alert(title: Text(alertMessage))
+        }
+    }
+}
+
+#Preview {
+    NavigationView {
+        ProfileView()
+            .environmentObject(AuthViewModel())
+    }
+}

--- a/Yuki/YukiApp.swift
+++ b/Yuki/YukiApp.swift
@@ -1,11 +1,17 @@
 import SwiftUI
 import FirebaseCore
+import GoogleSignIn
 
 class AppDelegate: NSObject, UIApplicationDelegate {
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
     FirebaseApp.configure()
     return true
+  }
+
+  func application(_ app: UIApplication, open url: URL,
+                   options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    return GIDSignIn.sharedInstance.handle(url)
   }
 }
 


### PR DESCRIPTION
## Summary
- enable Google Sign-In via Firebase
- store profile details in Firestore
- allow editing profile info

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688921a53c1c8328adc6cdadedb05235